### PR TITLE
WIP: Don't fail boot process if no TPM is available

### DIFF
--- a/grub-core/boot/i386/pc/boot.S
+++ b/grub-core/boot/i386/pc/boot.S
@@ -397,10 +397,10 @@ tcg_statuscheck:
 
 error_tpm_deactivated:
   MSG(deactivatedTPM_error_string)
-  jmp	LOCAL(general_error)
+  jmp	tcg_end
 error_no_tpm:
 	MSG(noTPM_error_string)
-	jmp	LOCAL(general_error)
+	jmp	tcg_end
 
 /*
  * BIOS call "INT 1Ah, (AH)=BBh, (AL)=07h" TCG_CompactHashLogExtendEvent
@@ -442,7 +442,6 @@ tcg_compacthashlogextendevent:
 	test	%eax, %eax
 	jz		tcg_end				/* if eax != 0 */
 	MSG(tcg_error_string)
-	jmp	LOCAL(general_error)
 
 tcg_end:
 	popa

--- a/grub-core/boot/i386/pc/diskboot.S
+++ b/grub-core/boot/i386/pc/diskboot.S
@@ -335,6 +335,26 @@ LOCAL(bootit):
 
 	/* hash and measure 512 bytes at the beginning of kernel_address */
 
+	/* Check for TPM availability */
+	/* TODO: Propably not necessary */
+/*
+ * BIOS call "INT 1Ah, (AH)=BBh,(AL)=00h" TCG_StatusCheck
+ *	Call with	%ah = 0xBB
+ *				%al = 0x00
+ *
+ *	Return:	%eax = TCG_STATUS == 0 if the system supports the TCG BIOS calls.
+ *			%ebx = 'TCPA'
+ *
+ * Ref:
+ *  TCG PC Client Specific Implementation Specification for Conventional BIOS v1.21,
+ *  Section 13.7 (page 115)
+ */
+tcg_statuscheck:
+	movw    $0xBB00, %ax		/* TCG_StatusCheck */
+	int     $0x1A
+	test	%eax, %eax
+	jnz	tcg_end			/* if eax != 0 */
+
 /*
  * BIOS call "INT 1Ah, (AH)=BBh, (AL)=07h" TCG_CompactHashLogExtendEvent
  *
@@ -380,7 +400,6 @@ tcg_compacthashlogextendevent:
 	test	%eax, %eax
 	jz		tcg_end				/* if eax != 0 */
 	MSG(tcg_error_string)
-	jmp	LOCAL(general_error)
 
 tcg_end:
 	popa

--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -756,7 +756,8 @@ grub_dl_load (const char *name)
 
   /* Begin TCG Extension */
   if( grub_errno == GRUB_ERR_NONE ) {
-	  grub_TPM_measureFile( filename, TPM_LOADED_FILES_PCR );
+	  if (grub_TPM_isAvailable())
+	    grub_TPM_measureFile( filename, TPM_LOADED_FILES_PCR );
   }
   /* End TCG Extension */
 

--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -224,6 +224,35 @@ grub_TPM_measure( const grub_uint8_t* inDigest, const unsigned long index ) {
 	grub_free( passThroughOutput );
 }
 
+static unsigned int grubTPM_AvailabilityAlreadyChecked = 0;
+static unsigned int grubTPM_isAvailable = 0;
+
+/* Returns 1 if TPM is available, 0 otherwise . */
+grub_uint32_t
+grub_TPM_isAvailable( void ) {
+
+	/* Checking for availability takes a while. so its useful to check this only once */
+	if( grubTPM_AvailabilityAlreadyChecked ) {
+		return grubTPM_isAvailable;
+	}
+
+	grub_uint32_t returnCode, featureFlags, eventLog, edi;
+	grub_uint8_t major, minor;
+
+	grub_err_t err = tcg_statusCheck( &returnCode, &major, &minor, &featureFlags, &eventLog, &edi );
+
+    if( err == GRUB_ERR_NONE ) {
+        grubTPM_isAvailable = 1;
+    } else {
+        grubTPM_isAvailable = 0;
+        grub_errno = GRUB_ERR_NONE;
+    }
+
+	grubTPM_AvailabilityAlreadyChecked = 1;
+
+	return grubTPM_isAvailable;
+}
+
 /* grub_fatal() on error */
 void
 grub_TPM_measureString( const char* string ) {

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -1043,7 +1043,8 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
   /* Begin TCG Extension */
   else {	/* file successfully loaded */
-	  grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
+	  if (grub_TPM_isAvailable())
+	    grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
   }
   /* End TCG Extension */
 

--- a/grub-core/loader/i386/pc/chainloader.c
+++ b/grub-core/loader/i386/pc/chainloader.c
@@ -242,7 +242,8 @@ grub_chainloader_cmd (const char *filename, grub_chainloader_flags_t flags)
   grub_loader_set (grub_chainloader_boot, grub_chainloader_unload, 1);
 
   /* Begin TCG Extension */
-  grub_TPM_measureFile( (char*)filename, TPM_LOADED_FILES_PCR );
+  if (grub_TPM_isAvailable())
+    grub_TPM_measureFile( (char*)filename, TPM_LOADED_FILES_PCR );
 
   /* End TCG Extension */
 

--- a/grub-core/loader/i386/pc/linux.c
+++ b/grub-core/loader/i386/pc/linux.c
@@ -383,7 +383,8 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
   /* Begin TCG Extension */
   else {	/* file successfully loaded */
-	  grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
+	  if (grub_TPM_isAvailable())
+	    grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
   }
   /* End TCG Extension */
 

--- a/grub-core/loader/i386/pc/ntldr.c
+++ b/grub-core/loader/i386/pc/ntldr.c
@@ -139,7 +139,8 @@ grub_cmd_ntldr (grub_command_t cmd __attribute__ ((unused)),
   grub_loader_set (grub_ntldr_boot, grub_ntldr_unload, 1);
 
   /* Begin TCG Extension */
-  grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
+  if (grub_TPM_isAvailable())
+    grub_TPM_measureFile( argv[0], TPM_LOADED_FILES_PCR );
   /* End TCG Extension */
 
   return GRUB_ERR_NONE;

--- a/grub-core/loader/linux.c
+++ b/grub-core/loader/linux.c
@@ -242,7 +242,8 @@ grub_initrd_close (struct grub_linux_initrd_context *initrd_ctx)
     {
 
       /* Begin TCG Extension */
-      grub_TPM_measureFile( initrd_ctx->components[i].file->name, TPM_LOADED_FILES_PCR );
+      if (grub_TPM_isAvailable())
+        grub_TPM_measureFile( initrd_ctx->components[i].file->name, TPM_LOADED_FILES_PCR );
       /* End TCG Extension */
 
       grub_free (initrd_ctx->components[i].newc_name);

--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -35,6 +35,8 @@
 #include <grub/bufio.h>
 
 /* BEGIN TCG EXTENSION */
+#include <grub/machine/tpm.h>
+
 #define TGRUB_VERSION "1.21"
 /* END TCG EXTENSION */
 
@@ -211,8 +213,11 @@ grub_normal_init_page (struct grub_term_output *term,
   grub_uint32_t *last_position;
  
   grub_term_cls (term);
-
-  msg_formatted = grub_xasprintf (_("TrustedGRUB2  version %s"), TGRUB_VERSION);
+ 
+  if( grub_TPM_isAvailable() )
+    msg_formatted = grub_xasprintf (_("TrustedGRUB2  version %s"), TGRUB_VERSION);
+  else
+    msg_formatted = grub_xasprintf (_("TrustedGRUB2  version %s [ No TPM detected! ]"), TGRUB_VERSION);
   if (!msg_formatted)
     return;
  

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -1050,7 +1050,8 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 	  command[grub_strlen( command )] = '\0';
 
 	  /*  measure string */
-	  grub_TPM_measureString( command );
+	  if (grub_TPM_isAvailable())
+	    grub_TPM_measureString( command );
   }
   /* End TCG Extension */
 

--- a/include/grub/i386/pc/tpm.h
+++ b/include/grub/i386/pc/tpm.h
@@ -64,6 +64,12 @@ typedef struct {
 /* print SHA1 hash of input */
 void EXPORT_FUNC(print_sha1) ( grub_uint8_t* inDigest );
 
+/* 	Checks for TPM availability
+	Returns 1 if available
+	Returns 0 if not
+*/
+grub_uint32_t EXPORT_FUNC(grub_TPM_isAvailable) ( void );
+
 /* 	Measure string */
 void EXPORT_FUNC(grub_TPM_measureString) ( const char* string );
 /* 	Measure file */


### PR DESCRIPTION
Hi!

I'm trying to adapt TrustedGRUB2 so that the boot process does not fail if no TPM is available. If the boot process fails if no TPM is available, then accidentally installing TrustedGRUB2 breaks systems without a TPM. That's not an acceptable default that would allow to safely integrate TrustedGRUB2 into a Linux distribution.

The current PR is my miserably failing attempt to make TrustedGRUB2 boot without TPM. I hoped that by masking every call into the API exposed through `tpm.h` with `grub_TPM_isAvailable` would be enough. But unfortunately, it isn't, and I don't find a way to debug it. Adding `-DTGRUB_DEBUG` as compile time option does not lead to any debug output.

So I wanted to ask for help! Could someone maybe have a quick look at my changes and suggest me how to proceed?

Many thanks!
