### PR TITLE
Fix security issue when reading username and password

### DIFF
--- a/grub-core/lib/crypto.c
+++ b/grub-core/lib/crypto.c
@@ -470,7 +470,8 @@ grub_password_get (char buf[], unsigned buf_size)
 
       if (key == '\b')
 	{
-	  cur_len--;
+	  if (cur_len)
+	    cur_len--;
 	  continue;
 	}
 

--- a/grub-core/normal/auth.c
+++ b/grub-core/normal/auth.c
@@ -174,8 +174,11 @@ grub_username_get (char buf[], unsigned buf_size)
 
       if (key == '\b')
 	{
-	  cur_len--;
-	  grub_printf ("\b");
+	  if (cur_len)
+	    {
+	      cur_len--;
+	      grub_printf ("\b");
+	    }
 	  continue;
 	}
 


### PR DESCRIPTION
This is the original commit from Hector Marco-Gisbert cherry picked from the grub2 repository!

This patch fixes two integer underflows at:
- grub-core/lib/crypto.c
- grub-core/normal/auth.c

CVE-2015-8370

Signed-off-by: Hector Marco-Gisbert hecmargi@upv.es
Signed-off-by: Ismael Ripoll-Ripoll iripoll@disca.upv.es
Also-By: Andrey Borzenkov arvidjaar@gmail.com
