### PR TITLE
In addition to menuentry, also don't measure submenu and [...] commands.

### DIFF
--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -1032,9 +1032,18 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 
   /* Begin TCG Extension */
 
-  /* do not measure "menuentry" command */
-  /* it makes precomputation of the pcr value difficult and is unnecessary because each command within the menuentry is anyway measured */
-  if( grub_strncmp( argv.args[0], "menuentry", grub_strlen( "menuentry" ) ) != 0 ) {
+  /* Do not measure the following commands:
+   * menuentry
+   * submenu
+   * [ ... ]
+   *
+   * They make precomputation of the PCR value difficult and is unnecessary
+   * because each command within menuentry and submeny is measured anyway. As
+   * for [ ... ], it seems it isn't possible to execute a command within those.
+   */
+  if ( grub_strncmp( argv.args[0], "menuentry", grub_strlen( "menuentry" ) ) != 0 &&
+       grub_strncmp( argv.args[0], "submenu", grub_strlen( "submenu" ) ) != 0 &&
+       grub_strncmp( argv.args[0], "[", grub_strlen( "[" ) ) != 0 ) {
 
 	  /* Build string for measurement containing command + args */
 	  char command[1024];


### PR DESCRIPTION
Both menuentry and submenu commands end up being very long because all
the contents between the braces is also part of the command arguments.
The conditional between square brackets is also not very useful to
measure since a command cannot be executed between two square brackets.
This is from skimming through the code in grub-core/commands/test.c.

The commands inside menuentry/submenu are all measured anyway so there
is no harm in not measuring them.
