### PR TITLE
Disable HP workaround in default mode. GH #18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ env:
 compiler: gcc
 language: c
 
+env:
+  - DEFINES=""
+  - DEFINES="CPPFLAGS=-DTGRUB_HP_WORKAROUND"
+  - DEFINES="CPPFLAGS=-DTGRUB_DEBUG"
 
 script:
   - "./autogen.sh"
   - "./configure --target=i386 -with-platform=pc"
-  - "make -j 4 --silent"
+  - "make DEFINES -j 4 --silent"
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 script:
   - "./autogen.sh"
   - "./configure --target=i386 -with-platform=pc"
+  - "echo ${DEFINES}"
   - "make ${DEFINES} -j 4 --silent"
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 script:
   - "./autogen.sh"
   - "./configure --target=i386 -with-platform=pc"
-  - "make DEFINES -j 4 --silent"
+  - "make ${DEFINES} -j 4 --silent"
 
 os:
   - linux

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 * Update to latest GRUB2 master (23.12.2015) that also includes a fix for CVE-2015-8370
 * Prevent possible buffer overlow in case the command to measure is greater than 1024 byte in length
 * Disable HP workaround in default mode, i.e. HP workaround has to be enabled explicitly by defining `TGRUB_HP_WORKAROUND`. Therefore there is no need 
-to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. 
+to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. GH #18
 
 #### 1.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 * Command measurement: in addition to not measuring `menuentry` also `submenu` and `[ ... ]` are not measured to simplify precomputation. GH #25
 * Update to latest GRUB2 master (23.12.2015) that also includes a fix for CVE-2015-8370
 * Prevent possible buffer overlow in case the command to measure is greater than 1024 byte in length
+* Disable HP workaround in default mode, i.e. HP workaround has to be enabled explicitly by defining `TGRUB_HP_WORKAROUND`. Therefore there is no need 
+to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. 
 
 #### 1.2.1
 

--- a/grub-core/boot/i386/pc/diskboot.S
+++ b/grub-core/boot/i386/pc/diskboot.S
@@ -69,6 +69,7 @@ _start:
 	 * will ever be a core.img larger than that. ;-) */
 	shll	$9, %eax
 
+#ifdef TGRUB_HP_WORKAROUND
 	/* HP workaround
 	 * This is a workaround for HP desktop/laptop BIOS which seem to be
 	 * unable to handle blocks ending on 512 byte boundaries when measuring
@@ -82,6 +83,7 @@ _start:
 	 * */
 	inc	%eax   /* add 1 to number_of_bytes_to_measure */
 	incw	8(%di) /* make code below read 1 more sector than specified */
+#endif
 
 	/* write result to number_of_bytes_to_measure var */
 	movl	%eax, number_of_bytes_to_measure

--- a/include/grub/i386/pc/tpm.h
+++ b/include/grub/i386/pc/tpm.h
@@ -4,8 +4,6 @@
 
 #include <grub/err.h>
 
-/* #define TGRUB_DEBUG */
-
 #ifdef TGRUB_DEBUG
 	#define DEBUG_PRINT( x ) grub_printf x
 #else

--- a/util/mkimage.c
+++ b/util/mkimage.c
@@ -1389,6 +1389,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
 	free (boot_path);
 
 /* BEGIN TCG EXTENSION */
+#ifdef TGRUB_HP_WORKAROUND
 	/* HP workaround */
 	/* core.img size has to be core_size % 512 != 0  */
         size_t newCoreImgSize = ALIGN_UP (core_size, 512);
@@ -1401,6 +1402,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
 
 	core_img = newCoreImg;
         core_size = newCoreImgSize;
+#endif
 /* END TCG EXTENSION */
       }
       break;


### PR DESCRIPTION
Workaround has to be explicitly enabled by defining `TGRUB_HP_WORKAROUND`

Closes #18 
