### PR TITLE
Measure buffer that is used

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
 * Prevent possible buffer overlow in case the command to measure is greater than 1024 byte in length
 * Disable HP workaround in default mode, i.e. HP workaround has to be enabled explicitly by defining `TGRUB_HP_WORKAROUND`. Therefore there is no need 
 to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. GH #18
+* Measure buffer that is used. Before this fix everything that was measured from disk was read a second time. This enabled following attack: A 
+sufficiently malicious storage device might provide a backdoored file on the first read attempt, followed by the correct file on the second read 
+attempt. The measurement would then appear correct. GH #9
 
 #### 1.2.1
 

--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -342,6 +342,7 @@ grub_TPM_measure_buffer( const void* buffer, const grub_uint32_t bufferLen, cons
 	DEBUG_PRINT( ( "SHA1: " ) );
     print_sha1( convertedResult );
     DEBUG_PRINT( ( "\n" ) );
+    grub_sleep( 4 );
 #endif
 
 	/* measure */

--- a/grub-core/loader/i386/pc/chainloader.c
+++ b/grub-core/loader/i386/pc/chainloader.c
@@ -205,6 +205,10 @@ grub_chainloader_cmd (const char *filename, grub_chainloader_flags_t flags)
 
   grub_file_close (file);
 
+  /* Begin TCG Extension */
+  grub_TPM_measure_buffer( bs, GRUB_DISK_SECTOR_SIZE, TPM_LOADED_FILES_PCR );
+  /* End TCG Extension */
+
   /* Obtain the partition table from the root device.  */
   drive = grub_get_root_biosnumber ();
   dev = grub_device_open (0);
@@ -240,11 +244,6 @@ grub_chainloader_cmd (const char *filename, grub_chainloader_flags_t flags)
   boot_part_addr = part_addr;
 
   grub_loader_set (grub_chainloader_boot, grub_chainloader_unload, 1);
-
-  /* Begin TCG Extension */
-  grub_TPM_measure_file( (char*)filename, TPM_LOADED_FILES_PCR );
-
-  /* End TCG Extension */
 
   return;
 

--- a/grub-core/loader/i386/pc/ntldr.c
+++ b/grub-core/loader/i386/pc/ntldr.c
@@ -141,7 +141,7 @@ grub_cmd_ntldr (grub_command_t cmd __attribute__ ((unused)),
   grub_loader_set (grub_ntldr_boot, grub_ntldr_unload, 1);
 
   /* Begin TCG Extension */
-  grub_TPM_measure_file( argv[0], TPM_LOADED_FILES_PCR );
+  grub_TPM_measure_buffer( ntldr, ntldrsize, TPM_LOADED_FILES_PCR );
   /* End TCG Extension */
 
   return GRUB_ERR_NONE;

--- a/grub-core/loader/linux.c
+++ b/grub-core/loader/linux.c
@@ -241,11 +241,6 @@ grub_initrd_close (struct grub_linux_initrd_context *initrd_ctx)
     return;
   for (i = 0; i < initrd_ctx->nfiles; i++)
     {
-
-      /* Begin TCG Extension */
-      grub_TPM_measure_file( initrd_ctx->components[i].file->name, TPM_LOADED_FILES_PCR );
-      /* End TCG Extension */
-
       grub_free (initrd_ctx->components[i].newc_name);
       grub_file_close (initrd_ctx->components[i].file);
     }
@@ -297,6 +292,10 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
 	  grub_initrd_close (initrd_ctx);
 	  return grub_errno;
 	}
+      /* Begin TCG Extension */
+      grub_TPM_measure_buffer( ptr, cursize, TPM_LOADED_FILES_PCR );
+      /* End TCG Extension */
+
       ptr += cursize;
     }
   if (newc)

--- a/include/grub/i386/pc/tpm.h
+++ b/include/grub/i386/pc/tpm.h
@@ -52,12 +52,6 @@
 
 /************************* macros *************************/
 
-#ifdef TGRUB_DEBUG
-	#define DEBUG_PRINT( x ) grub_printf x
-#else
-	#define DEBUG_PRINT( x )
-#endif
-
 #define CHECK_FOR_NULL_ARGUMENT( argument ) 						                    \
 			if( ! argument ) {										                    \
 				grub_fatal( "BAD_ARGUMENT: argument is NULL" );   				\

--- a/include/grub/tpm.h
+++ b/include/grub/tpm.h
@@ -34,6 +34,14 @@
 #define TPM_COMMAND_MEASUREMENT_PCR 11
 #define TPM_LUKS_HEADER_MEASUREMENT_PCR 12
 
+/************************* macros *************************/
+
+#ifdef TGRUB_DEBUG
+	#define DEBUG_PRINT( x ) grub_printf x
+#else
+	#define DEBUG_PRINT( x )
+#endif
+
 /************************* functions *************************/
 
 /* print SHA1 hash of input */


### PR DESCRIPTION
Before this fix everything that was measured from disk was read a second time.

This enabled following attack: A sufficiently malicious storage device might provide a backdoored file on the first read attempt, followed by the correct file on the second read attempt. The measurement would then appear correct. 

fixes #9 
