### PR TITLE
implemented multiboot measurement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,14 +6,10 @@
 * Command measurement: in addition to not measuring `menuentry` also `submenu` and `[ ... ]` are not measured to simplify precomputation. GH #25
 * Update to latest GRUB2 master (23.12.2015) that also includes a fix for CVE-2015-8370
 * Prevent possible buffer overlow in case the command to measure is greater than 1024 byte in length
-* Disable HP workaround in default mode, i.e. HP workaround has to be enabled explicitly by defining `TGRUB_HP_WORKAROUND`. Therefore there is no need 
-to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. GH #18
-* Measure buffer that is used. Before this fix everything that was measured from disk was read a second time. This enabled following attack: A 
-sufficiently malicious storage device might provide a backdoored file on the first read attempt, followed by the correct file on the second read 
-attempt. The measurement would then appear correct. GH #9
-* Measurements of parts of TrustedGRUB2 that are loaded at runtime like grub2-modules are now seperated from the loader measurements like kernel and initrd. Additionally renamed `TPM_LOADED_FILES_PCR` to 
-`TPM_LOADER_MEASUREMENT_PCR` and introduced a new define `TPM_GRUB2_LOADED_FILES_MEASUREMENT_PCR` for the GRUB2 measurements. GH #34
-
+* Disable HP workaround in default mode, i.e. HP workaround has to be enabled explicitly by defining `TGRUB_HP_WORKAROUND`. Therefore there is no need to append `--no-rs-codes` to `grub-install` anymore in case you don't need the workaround. GH #18
+* Measure buffer that is used. Before this fix everything that was measured from disk was read a second time. This enabled following attack: A sufficiently malicious storage device might provide a backdoored file on the first read attempt, followed by the correct file on the second read attempt. The measurement would then appear correct. GH #9
+* Measurements of parts of TrustedGRUB2 that are loaded at runtime like grub2-modules are now seperated from the loader measurements like kernel and initrd. Additionally renamed `TPM_LOADED_FILES_PCR` to `TPM_LOADER_MEASUREMENT_PCR` and introduced a new define `TPM_GRUB2_LOADED_FILES_MEASUREMENT_PCR` for the GRUB2 measurements. GH #34
+* Add multiboot measurements for `multiboot` and `module` commands. For now the `multiboot` measurement does not follow the new convention of measuring the same buffer that is loaded into memory. If someone needs this extra security feel free to send a pull request. GH #35
 
 #### 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This can only be done indirectly by using the seal/unseal functions of the TPM (
   * `initrd` / `initrd16`
   * `chainloader`
   * `ntdlr`
+  * `multiboot`
+  * `module`
 * New cryptomount parameters:
   * `cryptomount -k KEYFILE`
   * `cryptomount -k KEYFILE -s`
@@ -52,7 +54,7 @@ This can only be done indirectly by using the seal/unseal functions of the TPM (
 * PCR 0-7 Measured by BIOS
 * PCR 8 First sector of TrustedGRUB2 kernel (diskboot.img)
 * PCR 9 TrustedGRUB2 kernel (core.img)
-* PCR 10 Loader measurements - currently linux-kernel, initrd, ntldr, chainloader
+* PCR 10 Loader measurements - currently linux-kernel, initrd, ntldr, chainloader, multiboot, module
 * PCR 11 Contains all commandline arguments from scripts (e.g. grub.cfg) and those entered in the shell
 * PCR 12 LUKS-header
 * PCR 13 Parts of GRUB2 that are loaded from disk like GRUB2-modules // TODO: fonts, themes, locales
@@ -229,6 +231,9 @@ Sets Memory Overwrite Request (MOR) Bit. `DISABLEAUTODETECT` specifies if BIOS s
 * `initrd` / `initrd16`  
 * `chainloader`  
 * `ntdlr`
+* `multiboot`
+* `module`
+  * append `--nounzip` to get measuremens of the compressed file 
 
 These commands are modified to measure before loading. PCR 10 is extended.
 
@@ -246,7 +251,11 @@ All modifications have been commented with
 /* END TCG EXTENSION */
 ```
 
-### 2.8 File list
+### 2.8 Security considerations
+
+* The `multiboot` command measurement does not follow the new convention of measuring the same buffer that is loaded into memory. If someone needs this extra security feel free to send a pull request. See GH #9 and GH #38 for more details.
+
+### 2.9 File list
 
 The following list presents the files that have been added / modified to add TCG
 support to GRUB2.
@@ -263,6 +272,7 @@ support to GRUB2.
 * grub-core/kern/sha1.c
 * grub-core/disk/cryptodisk.c
 * grub-core/disk/luks.c
+* grub-core/loader/multiboot.c
 * grub-core/loader/linux.c
 * grub-core/loader/i386/linux.c
 * grub-core/loader/i386/pc/chainloader.c

--- a/grub-core/loader/multiboot.c
+++ b/grub-core/loader/multiboot.c
@@ -43,6 +43,10 @@
 #include <grub/memory.h>
 #include <grub/i18n.h>
 
+/* Begin TCG Extension */
+#include <grub/tpm.h>
+/* End TCG Extension */
+
 GRUB_MOD_LICENSE ("GPLv3+");
 
 #ifdef GRUB_MACHINE_EFI
@@ -298,6 +302,10 @@ grub_cmd_multiboot (grub_command_t cmd __attribute__ ((unused)),
       grub_relocator_unload (grub_multiboot_relocator);
       grub_multiboot_relocator = NULL;
       grub_dl_unref (my_mod);
+    } else {
+    	/* Begin TCG Extension */
+    	grub_TPM_measure_file( argv[0], TPM_LOADER_MEASUREMENT_PCR );
+    	/* End TCG Extension */
     }
 
   return grub_errno;
@@ -382,6 +390,11 @@ grub_cmd_module (grub_command_t cmd __attribute__ ((unused)),
 		    argv[0]);
       return grub_errno;
     }
+
+  /* Begin TCG Extension */
+  DEBUG_PRINT( ("measured multiboot module: %s \n", argv[0]) );
+  grub_TPM_measure_buffer( module, size, TPM_LOADER_MEASUREMENT_PCR );
+  /* End TCG Extension */
 
   grub_file_close (file);
   return GRUB_ERR_NONE;


### PR DESCRIPTION
Loader measurements for `multiboot` and `module` commands

Unfortunately the `multiboot` measurement uses the deprecated `measure_file` method which does not protect against malicious storage devices ( GH #9 ). I've tried to implement the `measure_buffer` method but it's a lot more work and maybe even requires grub2 api changes.

In any case i think it's really hard to exploit. But pull requests are welcome. I'll create an issue for that.

Closes #35
