### PR TITLE
Avoid TCG_hashLogExtendEvent

### DIFF
--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -267,10 +267,11 @@ grub_TPM_hashExtendAndLogPCR( const void* buffer, const grub_uint32_t bufferLen,
             grub_printf( "Event Logging not mandatory, using TPM_Extend\n" );
         } else {
 #ifdef TGRUB_DEBUG
+            grub_uint8_t pcrResult[SHA1_DIGEST_SIZE] = {0};
             DEBUG_PRINT( ( "event number: %u \n", outgoing.eventNum ) );
             DEBUG_PRINT( ( "Old PCR[%u]=", pcrIndex ) );
-            grub_TPM_readpcr( pcrIndex, &result[0] );
-            print_sha1( result );
+            grub_TPM_readpcr( pcrIndex, &pcrResult[0] );
+            print_sha1( pcrResult );
             DEBUG_PRINT( ( "\n\n" ) );
             grub_sleep( 4 );
 #endif
@@ -360,10 +361,11 @@ grub_TPM_extendAndLogPCR( const grub_uint8_t* inDigest, const grub_uint8_t pcrIn
               
     } else {
 #ifdef TGRUB_DEBUG
+        grub_uint8_t pcrResult[SHA1_DIGEST_SIZE] = {0};
         DEBUG_PRINT( ( "event number: %u \n", outgoing.eventNum ) );
         DEBUG_PRINT( ( "Old PCR[%u]=", pcrIndex ) );
-        grub_TPM_readpcr( pcrIndex, &result[0] );
-        print_sha1( result );
+        grub_TPM_readpcr( pcrIndex, &pcrResult[0] );
+        print_sha1( pcrResult );
         DEBUG_PRINT( ( "\n\n" ) );
         grub_sleep( 4 );
 #endif

--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -603,7 +603,9 @@ void
 grub_TPM_measure_string( const char* string, const grub_uint8_t index ) {
 
     CHECK_FOR_NULL_ARGUMENT( string )
-        
+#ifdef TGRUB_DEBUG
+    grub_printf("string to measure: '%s'\n", string);
+#endif
     /* measure with TPM_Extend if logging works, else fall back
      * to TCG_compactLogHashEvent.  Event logging is essential.
      */

--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -206,8 +206,8 @@ grub_TPM_int1A_compactHashLogExtendEvent( const grub_uint8_t* buffer, const grub
     struct grub_bios_int_registers regs;
     regs.flags = GRUB_CPU_INT_FLAGS_DEFAULT;
     regs.eax = 0xBB07;
-    regs.es = (((grub_addr_t) &buffer) & 0xffff0000) >> 4;
-    regs.edi = ((grub_addr_t) &buffer) & 0xffff;
+    regs.es = (((grub_addr_t) buffer) & 0xffff0000) >> 4;
+    regs.edi = ((grub_addr_t) buffer) & 0xffff;
 
     regs.ebx = TCPA;
     regs.ecx = bufferLen;
@@ -445,7 +445,7 @@ grub_TPM_int1A_passThroughToTPM( const PassThroughToTPM_InputParamBlock* input, 
 
 /* grub_fatal() on error */
 void
-grub_TPM_measure_string( const char* string ) {
+grub_TPM_measure_string( const char* string, const grub_uint8_t index ) {
 
     CHECK_FOR_NULL_ARGUMENT( string )
 
@@ -475,7 +475,7 @@ grub_TPM_measure_string( const char* string ) {
 #endif
 
     /* measure with compactHashLogExtendEvent */
-    grub_TPM_int1A_compactHashLogExtendEvent((const grub_uint8_t*) string, grub_strlen( string ), TPM_COMMAND_MEASUREMENT_PCR);
+    grub_TPM_int1A_compactHashLogExtendEvent((const grub_uint8_t*) string, grub_strlen( string ), index);
 }
 
 /* grub_fatal() on error */

--- a/grub-core/kern/i386/pc/tpm/tpm_kern.c
+++ b/grub-core/kern/i386/pc/tpm/tpm_kern.c
@@ -41,26 +41,6 @@ static const grub_uint32_t TPM_ORD_PcrRead = 0x00000015;
 static const grub_uint32_t TPM_ORD_Extend = 0x00000014;
 /************************* struct typedefs *************************/
 
-/* TCG_HashLogExtendEvent Input Parameter Block (Format 2) */
-/*typedef struct {
-    grub_uint16_t ipbLength;
-    grub_uint16_t reserved;
-    grub_uint32_t hashDataPtr;
-    grub_uint32_t hashDataLen;
-    grub_uint32_t pcrIndex;
-    grub_uint32_t reserved2;
-    grub_uint32_t logDataPtr;
-    grub_uint32_t logDataLen;
- } GRUB_PACKED EventIncoming;
-*/
-/* TCG_HashLogExtendEvent Output Parameter Block */
-/*typedef struct {
-    grub_uint16_t opbLength;
-    grub_uint16_t reserved;
-    grub_uint32_t eventNum;
-    grub_uint8_t  hashValue[SHA1_DIGEST_SIZE];
-} GRUB_PACKED EventOutgoing;
-*/
 typedef struct {
     grub_uint32_t pcrIndex;
     grub_uint32_t eventType;
@@ -69,7 +49,7 @@ typedef struct {
     grub_uint8_t event[0];
 } GRUB_PACKED Event;
 
-/* TCG_HashLogEvent Input Parameter Block */
+/* TCG_HashLogEvent Input Parameter Block (Format 2) */
 typedef struct {
     grub_uint16_t ipbLength;
     grub_uint16_t reserved;
@@ -110,9 +90,10 @@ typedef struct {
     grub_uint32_t paramSize;
     grub_uint32_t ordinal;
     grub_uint32_t pcrIndex;
-    grub_uint8_t pcr_value[SHA1_DIGEST_SIZE];
+    grub_uint8_t inDigest[SHA1_DIGEST_SIZE];
 } GRUB_PACKED PCRExtendIncoming;
 
+/* TPM_Extend Outgoing Operand */
 typedef struct {
     grub_uint16_t tag;
     grub_uint32_t paramSize;
@@ -215,10 +196,10 @@ grub_TPM_extendAndLogPCR( const grub_uint8_t* inDigest, grub_uint8_t pcrIndex, c
 
 /* grub_fatal() on error */
 void
-grub_TPM_extendpcr(const grub_uint8_t index, const grub_uint8_t* indigest, grub_uint8_t* result ) {
+grub_TPM_extendpcr(const grub_uint8_t index, const grub_uint8_t* inDigest, grub_uint8_t* result ) {
 
     CHECK_FOR_NULL_ARGUMENT( result )
-    CHECK_FOR_NULL_ARGUMENT( indigest )
+    CHECK_FOR_NULL_ARGUMENT( inDigest )
     
     PassThroughToTPM_InputParamBlock *passThroughInput = NULL;
     PCRExtendIncoming* pcrExtendIncoming = NULL;
@@ -242,7 +223,7 @@ grub_TPM_extendpcr(const grub_uint8_t index, const grub_uint8_t* indigest, grub_
     pcrExtendIncoming->ordinal = grub_swap_bytes32_compile_time( TPM_ORD_Extend );
     pcrExtendIncoming->pcrIndex = grub_swap_bytes32( (grub_uint32_t) index);
 
-    grub_memcpy(pcrExtendIncoming->pcr_value, indigest, SHA1_DIGEST_SIZE );
+    grub_memcpy(pcrExtendIncoming->inDigest, inDigest, SHA1_DIGEST_SIZE );
     
     passThroughOutput = grub_zalloc( outputlen );
     if( ! passThroughOutput ) {

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -1071,7 +1071,7 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 	  }
 
 	  /*  measure string */
-	  grub_TPM_measure_string( commandAndArgs );
+	  grub_TPM_measure_string( commandAndArgs, TPM_COMMAND_MEASUREMENT_PCR );
 
 	  grub_free( commandAndArgs );
   }

--- a/include/grub/tpm.h
+++ b/include/grub/tpm.h
@@ -56,6 +56,8 @@ void EXPORT_FUNC(grub_TPM_measure_file) ( const char* filename, const grub_uint8
 void EXPORT_FUNC(grub_TPM_measure_buffer) ( const void* buffer, grub_uint32_t bufferLen, const grub_uint8_t index );
 
 void EXPORT_FUNC(grub_TPM_readpcr) ( const grub_uint8_t index, grub_uint8_t* result );
+/* Extend PCR via pass-through */
+void EXPORT_FUNC(grub_TPM_extendpcr) ( const grub_uint8_t index, const grub_uint8_t* indigest, grub_uint8_t* result );
 
 void grub_TPM_unseal( const grub_uint8_t* sealedBuffer, const grub_size_t inputSize, grub_uint8_t** result, grub_size_t* resultSize );
 

--- a/include/grub/tpm.h
+++ b/include/grub/tpm.h
@@ -49,7 +49,7 @@
 void EXPORT_FUNC(print_sha1) ( grub_uint8_t* inDigest );
 
 /*  Measure string */
-void EXPORT_FUNC(grub_TPM_measure_string) ( const char* string );
+void EXPORT_FUNC(grub_TPM_measure_string) ( const char* string, const grub_uint8_t index );
 /*  Measure file */
 void EXPORT_FUNC(grub_TPM_measure_file) ( const char* filename, const grub_uint8_t index );
 /*  Measure buffer */


### PR DESCRIPTION
Avoid the problematic `TCG_hashLogExtendEvent` call by replacing it with a `TPM_Extend` followed by a `TCG_hashLogEvent`.  

I have not confirmed that this resolves the various related issues (#53, #45, possibly #52), but I wanted to submit the code for review as soon as possible.  I will check an end-to-end solution tomorrow and report back.
